### PR TITLE
Add block to vhost.conf denying access to scripts

### DIFF
--- a/assets/config/apache2/vhost.conf
+++ b/assets/config/apache2/vhost.conf
@@ -11,6 +11,9 @@
 	<Directory "/usr/share/self-service-password/">
 		Require all granted
         </Directory>
+	<Directory "/usr/share/self-service-password/scripts/">
+		Deny from all
+	</Directory>
 
 	LogLevel warn
 #	ErrorLog /var/log/apache2/ssp_error.log


### PR DESCRIPTION
Hi 

I suppose that access to the scripts folder should be denied. This needs to be done manually as stated in https://ltb-project.org/documentation/self-service-password/1.3/migration

Thanks.